### PR TITLE
Add open loop delay before trying to move disk

### DIFF
--- a/roles/create_kvm/defaults/main.yml
+++ b/roles/create_kvm/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for create_kvm
 pve_firewall: false
+pve_post_clone_delay_secs: 5
 pve_start: true
 pve_storage: local-lvm
 pve_update: true

--- a/roles/create_kvm/tasks/clone.yml
+++ b/roles/create_kvm/tasks/clone.yml
@@ -25,6 +25,16 @@
   ansible.builtin.set_fact:
     kvm_config: "{{ vm_data.stdout | from_json }}"
 
+# TODO this would be better as closed vs open loop, but what to wait_for ?
+- name: Wait for VM disk to register
+  ansible.builtin.pause:
+    seconds: "{{ pve_post_clone_delay_secs }}"
+  # don't need to wait when the target is the same as the node
+  when: >-
+    (pve_post_clone_delay_secs > 0)
+    and (item.disk in kvm_config)
+    and (not kvm_config[item.disk].startswith(item.get("storage", pve_storage)))
+
 - name: Move disk
   community.general.proxmox_disk:
     delete_moved: true


### PR DESCRIPTION
The move disk task after the clone will sometimes fail because proxmox can't find the disk. Some sort of API lag? This adds a configurable delay before trying the move.